### PR TITLE
Grammar fix to "dear haskell" article.

### DIFF
--- a/post/dear_haskell/index.html
+++ b/post/dear_haskell/index.html
@@ -521,7 +521,7 @@ someFunc-hspec.cabal
 
 <p>So ghci doesn&rsquo;t read the cabal config.
 If we replace <code>Data.String.Strip</code> with <code>Lib</code>.
-<code>stack build</code> is success full.</p>
+<code>stack build</code> is successful.</p>
 
 <p>Let&rsquo;s make a test for <code>someFunc</code></p>
 


### PR DESCRIPTION
s/success full/successful/